### PR TITLE
 로그인 테스트 문제 해결

### DIFF
--- a/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/controller/AuthControllerTest.java
+++ b/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/controller/AuthControllerTest.java
@@ -7,13 +7,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 @DisplayName("View 컨트롤러 - 인증")
 @Import(SecurityConfiguration.class)
-@WebMvcTest
+@WebMvcTest(Void.class)
 public class AuthControllerTest {
 
     private final MockMvc mvc;
@@ -28,7 +29,9 @@ public class AuthControllerTest {
         //When & Then
         mvc.perform(get("/login"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.content().contentType("text/html;charset=UTF-8"));
+                .andExpect(MockMvcResultMatchers.content().contentType("text/html;charset=UTF-8"))
+                .andDo(MockMvcResultHandlers.print());
+
 
     }
 }


### PR DESCRIPTION
'/login' 페이지는 직접 만든 컨트롤러가 아니고 스프링 시큐리티가 해주는 작업이므로 컨트롤러 테스트에서 읽어야 할 컨트롤러 빈이 없다. 이를 'Void.class'로 표현했다.

This closes #26 